### PR TITLE
Allow specify user context in GitHub Status window

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,17 +41,6 @@ runs:
           echo "path=$_path" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Set user defined context
-      id: user_context
-      shell: bash
-      run: |
-        ctx=${{ inputs.context }}
-        if [ "$ctx" == "" ]; then
-          echo "ctx=undefined >> "$GITHUB_OUTPUT"
-        else
-          echo "ctx=$ctx" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
@@ -63,7 +52,7 @@ runs:
     - name: Prepare needed variables
       shell: bash
       id: vars
-      run: export_variables.sh "${{ inputs.os_test }}" "${{ inputs.test_case }}" "${{ steps.user_context.outputs.ctx }}"
+      run: export_variables.sh "${{ inputs.os_test }}" "${{ inputs.test_case }}" "${{ inputs.context }}"
 
     - name: Check if ${{ steps.working_dir.outputs.path }}/${{ steps.vars.outputs.dockerfile }} is present
       id: check_dockerfile

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   working_dir: # used for s2i-core and s2i-base images only
     description: ''
     required: false
+  context: # used for user-defined prefix context
+    description: ''
+    required: false
 
 runs:
   using: 'composite'
@@ -38,6 +41,17 @@ runs:
           echo "path=$_path" >> "$GITHUB_OUTPUT"
         fi
 
+    - name: Set user defined context
+      id: user_context
+      shell: bash
+      run: |
+        ctx=${{ inputs.context }}
+        if [ "$ctx" == "" ]; then
+          echo "ctx=undefined >> "$GITHUB_OUTPUT"
+        else
+          echo "ctx=$ctx" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
@@ -49,7 +63,7 @@ runs:
     - name: Prepare needed variables
       shell: bash
       id: vars
-      run: export_variables.sh "${{ inputs.os_test }}" "${{ inputs.test_case }}"
+      run: export_variables.sh "${{ inputs.os_test }}" "${{ inputs.test_case }}" "${{ steps.user_context.outputs.ctx }}"
 
     - name: Check if ${{ steps.working_dir.outputs.path }}/${{ steps.vars.outputs.dockerfile }} is present
       id: check_dockerfile

--- a/export_variables.sh
+++ b/export_variables.sh
@@ -6,12 +6,16 @@ all_os="$public_ranch $private_ranch"
 
 os_test="$1" # options: centos7, c8s, c9s, fedora, rhel7, rhel8, rhel9, rhel9-unsubscribed
 test_case="$2" # options: container, openshift-4
+user_context="$3"
 if [ -z "$os_test" ] || ! echo "$all_os" | grep -q "$os_test" ; then
   echo "::error::os_test '$os_test' is not valid"
   echo "::warning::choose one of: $all_os"
   exit 5
 fi
 
+if [ -z "$user_context" ]; then
+  context_prefix="undefined"
+fi
 # container tests vs openshift tests
 case "$test_case" in
   "container")
@@ -31,7 +35,10 @@ case "$test_case" in
     ;;
 esac
 
-
+context_prefix=""
+if [ "$user_context" != "undefined" ]; then
+  context_prefix="$user_context -"
+fi
 
 # public vs private ranch
 if echo "$public_ranch" | grep -q "$os_test" ; then
@@ -51,18 +58,18 @@ dockerfile=Dockerfile."$os_test"
 case "$os_test" in
   "centos7")
     tmt_plan="centos7"
-    context="CentOS7$context_suffix"
+    context="$context_prefix CentOS7$context_suffix"
     dockerfile="Dockerfile"
     compose="CentOS-7"
     ;;
   "c9s")
     tmt_plan="c9s"
-    context="CentOS Stream 9"
+    context="$context_prefix CentOS Stream 9"
     compose="CentOS-Stream-9"
     ;;
   "c8s")
     tmt_plan="c8s"
-    context="CentOS Stream 8"
+    context="$context_prefix CentOS Stream 8"
     compose="CentOS-Stream-8"
     ;;
   "fedora")
@@ -72,24 +79,24 @@ case "$os_test" in
     ;;
   "rhel7")
     tmt_plan="rhel7$tmt_plan_suffix"
-    context="RHEL7$context_suffix"
+    context="$context_prefix RHEL7$context_suffix"
     compose="RHEL-7-LatestUpdated"
     ;;
   "rhel8")
     tmt_plan="rhel8$tmt_plan_suffix"
-    context="RHEL8$context_suffix"
+    context="$context_prefix RHEL8$context_suffix"
     compose="RHEL-8.8.0-Nightly"
     ;;
   "rhel9")
     tmt_plan="rhel9$tmt_plan_suffix"
-    context="RHEL9$context_suffix"
+    context="$context_prefix RHEL9$context_suffix"
     compose="RHEL-9.2.0-Nightly"
     ;;
   "rhel9-unsubscribed")
     os_test="rhel9"
     dockerfile="Dockerfile.$os_test"
     tmt_plan="rhel9-unsubscribed-docker"
-    context="RHEL9 - Unsubscribed host"
+    context="$context_prefix RHEL9 - Unsubscribed host"
     compose="RHEL-9.2.0-Nightly"
     ;;
   ""|*)

--- a/export_variables.sh
+++ b/export_variables.sh
@@ -6,16 +6,13 @@ all_os="$public_ranch $private_ranch"
 
 os_test="$1" # options: centos7, c8s, c9s, fedora, rhel7, rhel8, rhel9, rhel9-unsubscribed
 test_case="$2" # options: container, openshift-4
-user_context="$3"
+user_context="$3" # User can specify its own user-defined context, like 'Testing Farm - pytest - RHEL8'
 if [ -z "$os_test" ] || ! echo "$all_os" | grep -q "$os_test" ; then
   echo "::error::os_test '$os_test' is not valid"
   echo "::warning::choose one of: $all_os"
   exit 5
 fi
 
-if [ -z "$user_context" ]; then
-  context_prefix="undefined"
-fi
 # container tests vs openshift tests
 case "$test_case" in
   "container")
@@ -36,7 +33,7 @@ case "$test_case" in
 esac
 
 context_prefix=""
-if [ "$user_context" != "undefined" ]; then
+if [ -n "$user_context" ]; then
   context_prefix="$user_context -"
 fi
 


### PR DESCRIPTION
Allow specify user context in GitHub Status window

    The context after this modification looks like:
    In case of context is not specified, then status is:
    `Testing Farm - <OS> - <version>`

    In case of context is specified, then status is:
    `Testing Farm - <context> <OS> - <version>`

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
