### PR TITLE
fix: use GitHub context for passing variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,4 +74,4 @@ runs:
         tf_scope: ${{ steps.vars.outputs.tf_scope }}
         tmt_plan_regex: ${{ steps.vars.outputs.tmt_plan }}
         pull_request_status_name: "${{ steps.vars.outputs.context }} - ${{ steps.working_dir.outputs.path }}"
-        variables: "REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=${{ github.event.issue.number }};SINGLE_VERSION=${{ inputs.version }};OS=${{ steps.vars.outputs.os_test }};TEST_NAME=${{ steps.vars.outputs.test_name }}"
+        variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};REPO_NAME=${{ github.repository }};PR_NUMBER=${{ github.event.issue.number }};SINGLE_VERSION=${{ inputs.version }};OS=${{ steps.vars.outputs.os_test }};TEST_NAME=${{ steps.vars.outputs.test_name }}"


### PR DESCRIPTION
This should fix the issue when GitHub variables aren't expanded before passing to tfaga.

```
variables: REPO_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY;REPO_NAME=$GITHUB_REPOSITORY;PR_NUMBER=249;SINGLE_VERSION=1.20;OS=rhel9;TEST_NAME=test
```
