### PR TITLE
use main tfaga branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Schedule tests for ${{ steps.working_dir.outputs.path }} - ${{ steps.vars.outputs.os_test }}
       if: ${{ steps.check_exclude_file.outputs.files_exists == 'false' && steps.check_dockerfile.outputs.files_exists == 'true' }}
-      uses: sclorg/testing-farm-as-github-action@typescript
+      uses: sclorg/testing-farm-as-github-action@main
       with:
         api_key:  ${{ inputs[steps.vars.outputs.api_key] }}
         compose:  ${{ steps.vars.outputs.compose }}


### PR DESCRIPTION
the typescript branch is already merged into main. Let's use main branch until we release tfaga v2.0.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
