### PR TITLE
Add support for running Container PyTest in Testing Farm.

### DIFF
--- a/export_variables.sh
+++ b/export_variables.sh
@@ -21,6 +21,12 @@ case "$test_case" in
     context_suffix=""
     test_name="test"
     ;;
+  "container-pytest")
+    test_case="container-pytest"
+    tmt_plan_suffix="-docker-pytest"
+    context_suffix=" - PyTest"
+    test_name="test-pytest"
+    ;;
   "openshift-4")
     context_suffix=" - OpenShift 4"
     tmt_plan_suffix="-openshift-4"


### PR DESCRIPTION
Add support for running Container PyTest in Testing Farm.

The corresponding TMT plans will be
rhel8-docker-pytest and rhel9-docker-pytest

The name in GitHub status will be `RHEL8 - Pytest` or `RHEL9 - Pytest`

