### PR TITLE
The plans have names like 'rhel8-docker' 'rhel8-docker-pytest'

### DIFF
--- a/export_variables.sh
+++ b/export_variables.sh
@@ -17,24 +17,29 @@ fi
 case "$test_case" in
   "container")
     test_case="container"
-    tmt_plan_suffix="-docker"
+    tmt_plan_suffix="-docker$"
     context_suffix=""
     test_name="test"
     ;;
   "container-pytest")
     test_case="container-pytest"
-    tmt_plan_suffix="-docker-pytest"
+    tmt_plan_suffix="-docker-pytest$"
     context_suffix=" - PyTest"
     test_name="test-pytest"
     ;;
   "openshift-4")
     context_suffix=" - OpenShift 4"
-    tmt_plan_suffix="-openshift-4"
+    tmt_plan_suffix="-openshift-4$"
     test_name="test-openshift-4"
     ;;
   "openshift-pytest")
     context_suffix=" - PyTest - OpenShift 4"
-    tmt_plan_suffix="-openshift-pytest"
+    tmt_plan_suffix="-openshift-pytest$"
+    test_name="test-openshift-pytest"
+    ;;
+  "openshift-helms")
+    context_suffix=" - Helms - OpenShift 4"
+    tmt_plan_suffix="-openshift-helms$ "
     test_name="test-openshift-pytest"
     ;;
   ""|*)


### PR DESCRIPTION
The plans have names like 'rhel8-docker' 'rhel8-docker-pytest' and similar for RHEL9.

This pull request should fix in case 'rhel8-docker' is called then 'rhel8-docker-pytest' is not called by the same name.

In our private repository, https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans/-/tree/master/plans, we have plans like:
- rhel8-docker.fmf
- rhel8-docker-pytest.fmf
- rhel9-docker.fmf
- rhel9-docker-pytest.fmf
In case 'rhel8-docker' plan is called then 'rhel8-docker-pytest' should be one called as well.
This pull request fixes it.
Or the '$' can be add at the end here: https://github.com/sclorg/tfaga-wrapper/blob/main/action.yml#L78
