### PR TITLE
Add support for testing NodeJS upstream tests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'c9s/c10s/fedora/rhel8/rhel9/rhel9-unsubscribed/rhel10/rhel10-unsubscribed'
     required: true
   test_case:
-    description: 'container/openshift-4'
+    description: 'container/container-upstream/openshift-4/openshift-pytest'
     required: true
   public_api_key:
     description: ''

--- a/export_variables.sh
+++ b/export_variables.sh
@@ -5,7 +5,7 @@ private_ranch="rhel8 rhel9 rhel9-unsubscribed rhel10 rhel10-unsubscribed"
 all_os="$public_ranch $private_ranch"
 
 os_test="$1" # options:  c9s, c10s, fedora, rhel8, rhel9, rhel9-unsubscribed, rhel10, rhel10-unsubscribed
-test_case="$2" # options: container, openshift-4, openshift-pytest
+test_case="$2" # options: container, container-upstream, openshift-4, openshift-pytest
 user_context="$3" # User can specify its own user-defined context, like 'Testing Farm - pytest - RHEL8'
 if [ -z "$os_test" ] || ! echo "$all_os" | grep -q "$os_test" ; then
   echo "::error::os_test '$os_test' is not valid"
@@ -20,6 +20,12 @@ case "$test_case" in
     tmt_plan_suffix="-docker$"
     context_suffix=""
     test_name="test"
+    ;;
+  "container-upstream")
+    test_case="container-upstream"
+    tmt_plan_suffix="-docker$"
+    context_suffix=" - UpstreamTests"
+    test_name="test-upstream"
     ;;
   "container-pytest")
     test_case="container-pytest"


### PR DESCRIPTION
This pull request adds support for testing NodeJS Upstream tests by testing farm in PUll requests
