### PR TITLE
Update `export_variables.sh` RHEL-9.6.0-Nightly

### DIFF
--- a/export_variables.sh
+++ b/export_variables.sh
@@ -104,14 +104,14 @@ case "$os_test" in
   "rhel9")
     tmt_plan="rhel9$tmt_plan_suffix"
     context="$context_prefix RHEL9$context_suffix"
-    compose="RHEL-9.4.0-Nightly"
+    compose="RHEL-9.6.0-Nightly"
     ;;
   "rhel9-unsubscribed")
     os_test="rhel9"
     dockerfile="Dockerfile.$os_test"
     tmt_plan="rhel9-unsubscribed-docker"
     context="$context_prefix RHEL9 - Unsubscribed host"
-    compose="RHEL-9.4.0-Nightly"
+    compose="RHEL-9.6.0-Nightly"
     ;;
   "rhel10")
     tmt_plan="rhel10$tmt_plan_suffix"


### PR DESCRIPTION
Update `export_variables.sh` from RHEL-9.4.0-Nightly to RHEL-9.6.0-Nightly


